### PR TITLE
Corrections, issue 22

### DIFF
--- a/example/list_my_tracks_beat_per_minute.jl
+++ b/example/list_my_tracks_beat_per_minute.jl
@@ -1,0 +1,52 @@
+using Spotify
+using Spotify.Library
+using Spotify.Tracks
+
+function listallmine()
+    offset = 0
+    st, repeat_after_sec = library_get_saved_tracks(2, offset, "NO");
+    st
+    @info "Listing $(st.total) tracks. Pauses may occur due the the current API rate limit. It may be increased by calling the API with a wider scope."
+    offset = 0
+    while true
+        while true
+            repeat_after_sec !=0 && sleep(repeat_after_sec + 0.5)
+            st, repeat_after_sec = library_get_saved_tracks(50, offset, "NO")
+            repeat_after_sec > 5 && @info "Waiting for $repeat_after_sec s for library API. Scope may affect limits."        
+            repeat_after_sec == 0 && break
+        end
+        if length(st) != 0
+            for (i, t) in enumerate(get(st, :items, []))
+                tr = t.track
+                s1 = lpad(i + offset, 5)
+                s2 = lpad(tr.name, 100)
+                id = tr.id
+                te = 0
+                af = Spotify.JSON3.Object()
+                if Spotify.isid(id)
+                    while true
+                        repeat_after_sec !=0 && sleep(repeat_after_sec + 0.5)
+                        af, repeat_after_sec =  tracks_get_audio_features(id)
+                        if !(typeof(af)  <: Spotify.JSON3.Object)
+                            @warn typeof(af)
+                        end
+                        repeat_after_sec > 5 && @info "\n Waiting for $repeat_after_sec s for tracks API. Scope may affect limits."
+                        repeat_after_sec == 0 && break
+                    end
+                    te = round(Int64, get(af, :tempo, 0))
+                end
+                s3 = lpad(te, 4)
+                println(s1, s2, s3)
+            end
+        end
+        offset += length(st.items)
+        offset >= st.total && break
+    end
+end
+
+
+if !Spotify.has_ig_access_token()
+    Spotify.get_implicit_grant()
+    Spotify.wait_for_ig_access()
+end
+listallmine()

--- a/example/script_list_my_tracks.jl
+++ b/example/script_list_my_tracks.jl
@@ -1,0 +1,23 @@
+using Spotify
+using Spotify.Library
+if !Spotify.has_ig_access_token()
+    Spotify.get_implicit_grant()
+    Spotify.wait_for_ig_access()
+end
+offset = 0
+st, repeat_after_sec = library_get_saved_tracks(1, offset, "NO")
+@info "Listing $(st.total) tracks. Pauses may occur due the the current API rate limit."
+
+repeat_after_sec = 0
+while true
+    while true
+        repeat_after_sec !=0 && sleep(repeat_after_sec + 0.5)
+        st, repeat_after_sec = library_get_saved_tracks(50, offset, "NO")
+        repeat_after_sec == 0 && break
+    end
+    for (i, t) in enumerate(st.items)
+        println(lpad(i + offset, 5), t.track.name)
+    end
+    offset += length(st.items)
+    offset >= st.total && break
+end

--- a/readme.md
+++ b/readme.md
@@ -2,29 +2,32 @@
 An open-source interface for using the Spotify web API in Julia. 
 
 ## Progress...
-Right now, 40 API functions have been writte, roughly tested and organized by sub-modules as defined in Spotify's [documentation](https://developer.spotify.com/documentation/general/):
+Right now, 40 API functions have been written, roughly tested and organized by sub-modules as defined in Spotify's [documentation](https://developer.spotify.com/documentation/general/):
+
 * Albums, Artists, Browse, Episodes, Follow, Library
-* Markets, Personalization, Player, Playlists, Search
-* Shows, Tracks, UsersProfile, Objects
+* ~~Markets~~, Personalization, ~~Player~~, ~~Playlists~~, ~~Search~~
+* Shows, Tracks, ~~UsersProfile~~, ~~(Objects)~~
 
 Help wanted in adding the still-missing functions!
 
 Ouput from function calls is JSON3 objects, which can be readily manipulated in the REPL or in other packages.
 
-Input to all functions is basically strings, but some ad-hoc string types are defined. These provide potential input checking, and some assistance in finding dummy parameters. Dummy parameters are defined in the 'test' folder.
+Input to all functions is basically strings, but some ad-hoc string types are defined. These provide potential input checking, and some assistance in finding dummy parameters. Dummy parameters are defined in the 'test' folder, but more accessible through the menu system, see below.
 
 ## Example use
 
     using Julia
 
-This creates 'spotify_credentials.in' in your home directory, along with brief instructions on how to configure your 'client credentials'.
+This creates 'spotify_credentials.ini' in your `homedir()`, along with brief instructions on how to configure your 'client credentials'.
 
 For repetitive debugging, the quickest syntax is (this function uses the low-level 'Client credentials' scope):
+
 ```julia
-julia> include("test/generalize_calls.jl")
+julia> include("test/interactive_default_calls.jl")
 [ Info: Retrieving client credentials, which typically lasts 1 hour.
 [ Info: Expires at 2021-04-26T11:17:59.009. Access `spotcred()`, refresh with `refresh_spotify_credentials()`.
 show_default_call (generic function with 2 methods)
+pick_function (generic function with 1 method)
 
 julia> using Spotify.Artists
 
@@ -46,13 +49,9 @@ julia>
 
 ```
 
-Irritatingly, this puts you in the 'test' folder, so: `cd("..")` to get back.
-
-For those of us who don't remember function numbers, there's an interactive menu, useful for configuring your setup and finding out which submodules to load.
+For those of us who don't remember function numbers, there's an interactive menu (not part of the package as such):
 
 ```julia
-julia> include("test/interactive_default_calls.jl")
-pick_function (generic function with 1 method)
 
 julia> using Spotify.Artists, Spotify.Follow
 
@@ -76,7 +75,6 @@ Pick function
     6 :(artist_get_related_artists(7HGFXtBhRq3g1Ma3nH4Rgv))
 
 Now calling:
-          :(artist_get(7HGFXtBhRq3g1Ma3nH4Rgv))
 [ Info: client-credentials
 JSON3.Object{Base.CodeUnits{UInt8, String}, Vector{UInt64}} with 10 entries:
   :external_urls => {…
@@ -92,23 +90,7 @@ JSON3.Object{Base.CodeUnits{UInt8, String}, Vector{UInt64}} with 10 entries:
 
 Response after 305 milliseconds
 
-Pick function
-[press: enter = select, q=quit]
- →  3 :(artist_get(7HGFXtBhRq3g1Ma3nH4Rgv))
-    4 :(artist_get_albums(7HGFXtBhRq3g1Ma3nH4Rgv, "album,single,appears_on,compilation", "NO", 10, 0))
-    5 :(artist_top_tracks(7HGFXtBhRq3g1Ma3nH4Rgv, "NO"))
-    6 :(artist_get_related_artists(7HGFXtBhRq3g1Ma3nH4Rgv))
-
-julia> 
-```
-
-When you try this yourself, we hope you appreciate the colors! 'Artist' and 'Follow'
-were highlighted.
-A the end, there, we pressed 'q' to quit. But what about the 'Follow' module?
-Those functions require a higher authority, so while reading the following example you need to imagine a web-browser asyncronously popping up in front of you, and you clicking accept!
-
-Let's restart the menu:
-```julia
+julia> using Spotify.Follow
 
 julia> pick_function()
 Pick group (red: module not loaded)
@@ -127,9 +109,9 @@ Pick function
  → 15 :(follow_check("artist", 74ASZWbe4lXaubB36ztrGX, 08td7MxkoHQkXnWAYD8d6Q))
    16 :(follow_check_playlist(5o5IGyk4tKO7A0DkVpstN0, 74ASZWbe4lXaubB36ztrGX, 08td7MxkoHQkXnWAYD8d6Q))
    17 :(follow_artists("artist", 10))
-   18 :(follow_artists_users("artist", 74ASZWbe4lXaubB36ztrGX, 08td7MxkoHQkXnWAYD8d6Q))      
+   18 :(follow_artists_users("artist", 74ASZWbe4lXaubB36ztrGX, 08td7MxkoHQkXnWAYD8d6Q))
    19 :(follow_playlist(5o5IGyk4tKO7A0DkVpstN0))
-   20 :(unfollow_artists_users("artist", 74ASZWbe4lXaubB36ztrGX, 08td7MxkoHQkXnWAYD8d6Q))    
+   20 :(unfollow_artists_users("artist", 74ASZWbe4lXaubB36ztrGX, 08td7MxkoHQkXnWAYD8d6Q))
    21 :(unfollow_playlist(5o5IGyk4tKO7A0DkVpstN0))
 
 Now calling:
@@ -140,58 +122,42 @@ Now calling:
         Launching a browser at: https://accounts.spotify.com/authorize?client_id=d972bafe04d34e98ab22f5d2bd7751b8&redirect_uri=http:%2F%2F127.0.0.1:8080%2Fapi&scope=user-read-private%20user-read-email%20user-follow-read&show_dialog=true&response_type=token&state=987
         Trying to launch browser candidate: firefox
 ┌ Warning: Current scope not valid, exiting call: user-follow-read
-└ @ Spotify c:\Users\frohu_h4g8g6y\.julia\dev\Spotify\src\util\utilities.jl:20
+└ @ Spotify C:\Users\frohu_h4g8g6y\.julia\dev\Spotify.jl\src\util\utilities.jl:20
 ()
 
-Response after 522 milliseconds
+Response after 496 milliseconds
 
 
-julia> 
+julia>
+        Implicit grant token expires at 2021-04-26T17:40:10.987 - closing server
+julia>
 
-        Implicit grant token expires at 2021-04-26T11:34:20.161 - closing server
+```
+When you try this yourself, we hope you appreciate the colors! You noticed how we were kicked out of the menu system because the 'Client credentials' were not sufficient here? We clicked 'Accept' in the browser that popped up, and we got a higher permission for the next hour. 
 
-julia> pick_function()
-Pick group (red: module not loaded)
-[press: d=done, a=all, n=none]
-   ⬚ 1:2         Albums
-   ⬚ 3:6         Artists
-   ⬚ 7:13        Browse
-   ⬚ 14:14       Episodes
- → ✓ 15:21       Follow
-   ⬚ 22:33       Library
-   ⬚ 34:35       Personalization
-   ⬚ 36:37       Player
-   ⬚ 38:40       Playlists
-Pick function
-[press: enter = select, q=quit]
- → 15 :(follow_check("artist", 74ASZWbe4lXaubB36ztrGX, 08td7MxkoHQkXnWAYD8d6Q))
-   16 :(follow_check_playlist(5o5IGyk4tKO7A0DkVpstN0, 74ASZWbe4lXaubB36ztrGX, 08td7MxkoHQkXnWAYD8d6Q))
-   17 :(follow_artists("artist", 10))
-   18 :(follow_artists_users("artist", 74ASZWbe4lXaubB36ztrGX, 08td7MxkoHQkXnWAYD8d6Q))
-   19 :(follow_playlist(5o5IGyk4tKO7A0DkVpstN0))
-   20 :(unfollow_artists_users("artist", 74ASZWbe4lXaubB36ztrGX, 08td7MxkoHQkXnWAYD8d6Q))
-   21 :(unfollow_playlist(5o5IGyk4tKO7A0DkVpstN0))
+Now we could `pick_function()` again, but let's call the function directly with an interesting artist, 'Chinese man'!
 
-Now calling:
-          :(follow_check("artist", 74ASZWbe4lXaubB36ztrGX, 08td7MxkoHQkXnWAYD8d6Q))
+```julia
+
+
+julia> strip_embed_code("""<iframe src="https://open.spotify.com/embed/artist/6vgw0jwJkUnW2NR1rzsQU3" width="300" height="380" frameborder="0" allowtransparency="true" allow="encrypted-media"></iframe>""")
+"6vgw0jwJkUnW2NR1rzsQU3"
+
+julia> # We copy the function call from above, but replace the embed code with what we just found:
+
+julia> follow_check("artist", "6vgw0jwJkUnW2NR1rzsQU3")
 [ Info: user-follow-read
 [ Info: We just try without checking if grant includes scope user-follow-read.
-2-element JSON3.Array{Bool, Base.CodeUnits{UInt8, String}, Vector{UInt64}}:
- 0
- 0
+1-element JSON3.Array{Bool, Base.CodeUnits{UInt8, String}, Vector{UInt64}}:
+ 1
 
-Response after 312 milliseconds
+julia> ans[1]
+true
 
-Pick function
-[press: enter = select, q=quit]
- → 15 :(follow_check("artist", 74ASZWbe4lXaubB36ztrGX, 08td7MxkoHQkXnWAYD8d6Q))
-   16 :(follow_check_playlist(5o5IGyk4tKO7A0DkVpstN0, 74ASZWbe4lXaubB36ztrGX, 08td7MxkoHQkXnWAYD8d6Q))
-   17 :(follow_artists("artist", 10))
-   18 :(follow_artists_users("artist", 74ASZWbe4lXaubB36ztrGX, 08td7MxkoHQkXnWAYD8d6Q))
-   19 :(follow_playlist(5o5IGyk4tKO7A0DkVpstN0))
-   20 :(unfollow_artists_users("artist", 74ASZWbe4lXaubB36ztrGX, 08td7MxkoHQkXnWAYD8d6Q))
-   21 :(unfollow_playlist(5o5IGyk4tKO7A0DkVpstN0))
+julia> # Yes, I follow this artist
 ```
+
+
 
 # To Do
 * Inline Documentation needs to be completed

--- a/src/Spotify.jl
+++ b/src/Spotify.jl
@@ -40,6 +40,17 @@ end
 
 const SPOTCRED  = Ref{SpotifyCredentials}(SpotifyCredentials())
 
+"""
+These permissions are not requested until the current scope is
+insufficient, or the user calls 'get_implicit_grant()'
+
+Default requested permissions are 'client-credentials'.
+"""
+const DEFAULT_IMPLICIT_GRANT = ["user-read-private",
+                                "user-read-email",
+                                "user-follow-read",
+                                "user-library-read"]
+
 spotcred() = SPOTCRED[]
 
 # Helper types - colorful aliases for 'String'.

--- a/src/authorization/implicit_grant_flow.jl
+++ b/src/authorization/implicit_grant_flow.jl
@@ -67,10 +67,7 @@ end
 
 
 function launch_a_browser_that_asks_for_implicit_grant()
-    vs =["user-read-private",
-        "user-read-email",
-        "user-follow-read"]
-    scopes = join(vs, "%20")
+    scopes = join(DEFAULT_IMPLICIT_GRANT, "%20")
     uri = OAUTH_AUTHORIZE_URL * "?" *
             "client_id=" * spotcred().client_id *
             "&redirect_uri=" * replace(spotcred().redirect, "/" => "%2F") *

--- a/src/by_reference_doc/library.jl
+++ b/src/by_reference_doc/library.jl
@@ -13,7 +13,7 @@
 [Reference](https://developer.spotify.com/documentation/web-api/reference/library/get-users-saved-tracks/)
 """ ->
 function library_get_saved_tracks(limit=20, offset=0, market="US")
-    return spotify_request("me/tracks?market=$market&offset=$offset&limit=$limit")
+    return spotify_request("me/tracks?market=$market&offset=$offset&limit=$limit"; scope = "user-library-read")
 end
 
 ## https://developer.spotify.com/documentation/web-api/reference/library/get-users-saved-shows/
@@ -28,7 +28,7 @@ end
 [Reference](https://developer.spotify.com/documentation/web-api/reference/library/get-users-saved-shows/)
 """ ->
 function library_get_saved_shows(limit=20, offset=0)
-    return spotify_request("me/shows?limit=$limit&offset=$offset")
+    return spotify_request("me/shows?limit=$limit&offset=$offset"; scope = "user-library-read")
 end
 
 
@@ -45,7 +45,7 @@ end
 [Reference](https://developer.spotify.com/documentation/web-api/reference/library/get-users-saved-albums/)
 """ ->
 function library_get_saved_albums(limit=20, offset=0, market="US")
-    return spotify_request("me/albums?limit=$limit&offset=$offset&market=$market")
+    return spotify_request("me/albums?limit=$limit&offset=$offset&market=$market"; scope = "user-library-read")
 end
 
 

--- a/src/export_structure.jl
+++ b/src/export_structure.jl
@@ -69,11 +69,9 @@ baremodule Personalization
 end
 baremodule Player
     import ..@_ie
-    @_ie show_get show_get_episodes
 end
 baremodule Playlists
     import ..@_ie
-    @_ie tracks_get_audio_analysis tracks_get_audio_features tracks_get
 end
 baremodule Search
     import ..@_ie
@@ -81,11 +79,11 @@ baremodule Search
 end
 baremodule Shows
     import ..@_ie
-    @_ie 
+    @_ie show_get show_get_episodes
 end
 baremodule Tracks
     import ..@_ie
-    @_ie tracks_get
+    @_ie tracks_get_audio_analysis tracks_get_audio_features tracks_get
 end
 baremodule UsersProfile
     import ..@_ie

--- a/src/util/utilities.jl
+++ b/src/util/utilities.jl
@@ -7,7 +7,6 @@ function parse_response(resp)
 end
 
 function header_maker(;scope="client-credentials")
-    @info scope
     if scope == "client-credentials"
         if client_credentials_still_valid()
             return ["Authorization" => "Bearer $(spotcred().access_token)"]
@@ -26,7 +25,7 @@ function has_valid_bearer(scope)
         # No check if it has expired yet.
         spotcred().access_token != ""
     elseif has_ig_access_token()
-        @info "We just try without checking if grant includes scope $scope."
+        @info "We try the request without checking if current grant includes scope $scope." maxlog = 3
         true
     else
         @info "Starting asyncronous user authorization process. Try again later!"

--- a/test/interactive_default_calls.jl
+++ b/test/interactive_default_calls.jl
@@ -4,13 +4,18 @@ include("generalize_calls.jl")
 
 is_loaded(foo) = isdefined(Main, foo)
 
+# This menu needs to be updated quite manually, together with 
+# verb_vec.jl and 'export_structure.jl. It would
+# be nice if we could easily read which methods are loaded,
+# but that would require some elaborate Core.eval...
+# This 'problem' goes away when the list is complete!
 function pick_modules(;verb_vec = verb_vec)
     !isdefined(Main, :Spotify) && return "-> using Spotify"
     submods = [:Albums, :Artists, :Browse, :Episodes, 
         :Follow, :Library, #:Markets,# 
-        :Personalization, :Player, :Playlists,
-        :Search, :Shows, :Tracks, 
-        :UsersProfile, :Objects]
+        :Personalization, #:Player, :Playlists, #:Search,
+        :Shows, :Tracks #, :UsersProfile, :Objects
+    ]
 
     foodi = Dict{Int, UnitRange}(
             1 => 1:2,
@@ -75,7 +80,7 @@ function pick_function(;verb_vec = verb_vec)
         print("Now calling:\n\t  ")
         show_default_call(no)
         t0 = now()
-        r = make_default_call(no)
+        r = make_default_call(no)[1] # Disregard the second output, which is how many seconds to wait...
         t1 = now()
         display(r)
         println()

--- a/test/verb_vec.jl
+++ b/test/verb_vec.jl
@@ -18,13 +18,13 @@
 :library_save_show,  :library_save_track,
 #= 34-35 Personalization 2 functions =#
 :top_tracks,  :top_artists,
-#= 36-37 Player 2 functions =#
-:show_get,  :show_get_episodes,
-#= 38-40 Playlists 3 functions =#
-:tracks_get_audio_analysis,  :tracks_get_audio_features,  :tracks_get
+#= Player =#
+#= Playlists =#
 #= Search =#
-#= Shows =#
-#= Tracks =#
+#= 36-37 Shows 2 functions =#
+:show_get,  :show_get_episodes,
+#= 38-40 Tracks 3 functions =#
+:tracks_get_audio_analysis, :tracks_get_audio_features, :tracks_get
 #= UsersProfile =#
 #= Objects =#
 ]


### PR DESCRIPTION
Incomplete fix of issue 22 - there is still dead code. But this works better already.
Also added a couple of half-useful script examples. 

new file:   example/list_my_tracks_beat_per_minute.jl
new file:   example/script_list_my_tracks.jl
modified:   readme.md            Update procedure, strikethrough missing
modified:   src/Spotify.jl       Default implicit grant now outside mutable
modified:   src/authorization/implicit_grant_flow.jl Refer to global for scopes.
modified:   src/by_reference_doc/library.jl    Add permission scope
modified:   src/export_structure.jl  Move funcs to correct modules
modified:   src/util/request.jl      Add retry_in_seconds output, type stable
modified:   src/util/utilities.jl    Limit @info repeats to 3.
modified:   test/interactive_default_calls.jl  Corrected func placement in modules.
modified:   test/verb_vec.jl          Corrected misplaced funcs