### PR TITLE
More endpoints + tests + docstrings

### DIFF
--- a/src/by_reference_doc/shows.jl
+++ b/src/by_reference_doc/shows.jl
@@ -1,36 +1,86 @@
-# shows.jl
-## https://developer.spotify.com/documentation/web-api/reference/shows/
+# Shows are the same as podcasts on Spotify
 
-## https://developer.spotify.com/documentation/web-api/reference/shows/get-a-show/
-@doc """
-# Get a Show
-**Summary**: Get a Spotify catalog information for a single show identified by it's unique Spotify ID.\n
+## https://developer.spotify.com/documentation/web-api/reference/#/operations/get-a-show
 
-`show_id` _Required_: The Spotify ID for the show. Up to 50 shows can be passed seperated with a comma. No whitespace.\n
-`market` _Optional_: An ISO 3166-1 alpha-2 country code.
-If a country code is specified, only shows and episodes that are available in that market will be returned.
-
-[Reference](https://developer.spotify.com/documentation/web-api/reference/shows/get-a-show/)
 """
-function show_get(show_id, market="US")
+    show_get(show_id; market="US")
+
+**Summary**: Get a Spotify catalog information for a single show identified by it's unique Spotify ID.
+
+# Arguments
+- `show_id` : The Spotify ID for the show
+
+# Optional keywords
+- `market` : An ISO 3166-1 alpha-2 country code. If a country code is specified, only shows 
+             and episodes that are available in that market will be returned.
+
+# Example
+```julia-repl
+julia> Spotify.show_get_single("2MAi0BvDc6GTFvKFPXnkCL")[1]
+JSON3.Object{Base.CodeUnits{UInt8, String}, Vector{UInt64}} with 18 entries:
+  :available_markets    => ["AD", "AE", "AG", "AL", "AM", "AR", "AT", "AU", "BA", "BB"  …  "TV", "TW", "US", "UY", "VC", …
+  :copyrights           => Union{}[]
+  :description          => "Conversations about science, technology, history, philosophy and the nature of intelligence, …
+  :episodes             => {…
+```
+"""
+function show_get_single(show_id; market::String="US")    
     return spotify_request("shows/$show_id?market=$market") 
 end
 
 
+## https://developer.spotify.com/documentation/web-api/reference/#/operations/get-multiple-shows
 
-## https://developer.spotify.com/documentation/web-api/reference/shows/get-shows-episodes/
-@doc """
-# Get a Show's Episodes 
-**Summary**: Get Spotify catalog information about a show’s episodes. Optional parameters can be used to limit the number of episodes returned.
+"""
+    show_get_multiple(ids; market::String="US")
 
-`show_id` _Required_: The Spotify ID for the show.\n 
-`market` _Optional_: Optional. An ISO 3166-1 alpha-2 country code.
-If a country code is specified, only shows and episodes that are available in that market will be returned.\n 
-`limit` _Optional_: The maximum number of episodes to return. Default = 20. Minimum 1. Maximum 50
-`offset` _Optional_: The index of the first episode to return. Default: 0 (the first object). Use the limit to get the next set of episodes.\n
+**Summary**: Get Spotify catalog information for several shows based on their Spotify IDs. 
 
-[Reference](https://developer.spotify.com/documentation/web-api/reference/shows/get-shows-episodes/)
-""" ->
-function show_get_episodes(show_id, market="US", limit=20, offset=0)
+# Arguments
+- `ids` : A comma-separated list of the Spotify IDs for the shows. Maximum: 50 IDs.
+
+# Optional keywords
+- `market` : An ISO 3166-1 alpha-2 country code. If a country code is specified, only shows 
+             and episodes that are available in that market will be returned.
+
+# Example
+```julia-repl
+julia> Spotify.show_get_multiple("2MAi0BvDc6GTFvKFPXnkCL, 4rOoJ6Egrf8K2IrywzwOMk")[1]
+JSON3.Object{Base.CodeUnits{UInt8, String}, Vector{UInt64}} with 1 entry:
+  :shows => JSON3.Object[{…
+```
+"""
+function show_get_multiple(ids; market::String="US")
+    return spotify_request("shows/?ids=$ids&market=$market")
+end
+
+
+## https://developer.spotify.com/documentation/web-api/reference/#/operations/get-a-shows-episodes
+"""
+    show_get_episodes(show_id; market="US", limit=20, offset=0)
+
+**Summary**: Get Spotify catalog information about a show’s episodes. Optional parameters 
+             can be used to limit the number of episodes returned.
+
+# Arguments
+- `show_id` : The Spotify ID for the show
+
+# Optional keywords
+- `market::String` : An ISO 3166-1 alpha-2 country code. If a country code is specified, 
+                     only episodes that are available in that market will be returned. 
+                     Default is set to "US".
+- `limit::Int64` : Maximum number of items to return, default is set to 20. (0 < limit <= 50)
+- `offset::Int64` : Index of the first item to return, default is set to 0
+
+# Example
+```julia-repl
+julia> Spotify.show_get_episodes("2MAi0BvDc6GTFvKFPXnkCL")[1]
+JSON3.Object{Base.CodeUnits{UInt8, String}, Vector{UInt64}} with 7 entries:
+  :href     => "https://api.spotify.com/v1/shows/2MAi0BvDc6GTFvKFPXnkCL/episodes?offset=0&limit=20&market=US"
+  :items    => JSON3.Object[{…
+  :limit    => 20
+``` 
+"""
+function show_get_episodes(show_id; market::String="US", limit::Int64=20, offset::Int64=0)
     return spotify_request("shows/$show_id/episodes?market=$market&limit=$limit&offset=$offset")
 end

--- a/src/export_structure.jl
+++ b/src/export_structure.jl
@@ -79,11 +79,11 @@ baremodule Search
 end
 baremodule Shows
     import ..@_ie
-    @_ie show_get show_get_episodes
+    @_ie show_get_single show_get_episodes
 end
 baremodule Tracks
     import ..@_ie
-    @_ie tracks_get_audio_analysis tracks_get_audio_features tracks_get
+    @_ie tracks_get_audio_analysis tracks_get_audio_features tracks_get_single
 end
 baremodule UsersProfile
     import ..@_ie


### PR DESCRIPTION
This PR contains more endpoints + unit tests + updated docstrings for GET-request functions in:
- shows.jl