### PR TITLE
Fix removal of items from playlist

### DIFF
--- a/src/by_reference_doc/playlists.jl
+++ b/src/by_reference_doc/playlists.jl
@@ -287,7 +287,8 @@ function playlist_remove_playlist_item(playlist_id, track_ids)
     pli = SpPlaylistId(playlist_id)
     url = "playlists/$pli/tracks"
     uris = SpTrackId.(track_ids)
-    body = body_string(;uris)
+    tracks = ["uri"=>uri for uri in uris]
+    body = body_string(;tracks)
     spotify_request(url, method; body, scope= "playlist-modify-private")
 end
 


### PR DESCRIPTION
Make behaviour of `playlist_remove_playlist_item` match expected behaviour as described in [docs](https://developer.spotify.com/documentation/web-api/reference/remove-tracks-playlist)